### PR TITLE
Add <title> to padlock SVG in server browser

### DIFF
--- a/wwwroot/js/browser.js
+++ b/wwwroot/js/browser.js
@@ -128,7 +128,7 @@ function renderBrowserList(servers) {
         html += '<span class="game-pill game-pill-' + gameClass + '">' + escapeHtml(s.game || 'GW2') + '</span> ';
         html += '<span class="browser-entry-motd motd-rendered">' + (typeof renderMotd === 'function' ? renderMotd(motd) : escapeHtml(motd)) + '</span>';
         if (s.hasPassword) {
-            html += ' <svg class="browser-lock-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>';
+            html += ' <svg class="browser-lock-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><title>This server is password protected</title><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>';
         }
         html += '</div>';
         html += '<div class="browser-entry-meta">';


### PR DESCRIPTION
Hey, this is my first pull request so apolgies for any errors.

Huge fan of this project, hopefully want to start contributing, thought I'd start with a really small change.

In the server browser, I was slightly unsure what the padlock symbol meant, with a bit of thought it's pretty obvious that it means the server has a password but I thought adding the title would make for a nicer UX, even if very few people will mouse over the SVG.

Thanks!