### PR TITLE
Added exception for laser goats in TeamVanquishGoats0

### DIFF
--- a/Server/Source/Anticheat/LoadoutValidator.cpp
+++ b/Server/Source/Anticheat/LoadoutValidator.cpp
@@ -283,6 +283,8 @@ void LoadoutValidator::init()
         {"Gameplay/Kits/Zombie_ZombossCat",     "Gameplay/Weapons/ZombossCat/",  "Endless0",     "MpZombie_ZombossCat"},
         {"Gameplay/Kits/Plant_Junkasaurus_CvD", "Gameplay/Weapons/Junkasaurus/", "CatsVsDinos0", "MpPlant_Junkasaurus_CvD"},
         {"Gameplay/Kits/Zombie_ZombossCat_CvD", "Gameplay/Weapons/ZombossCat/",  "CatsVsDinos0", "MpZombie_ZombossCat_CvD"},
+        {"Gameplay/Kits/Plant_LaserGoat_Green", "Gameplay/Weapons/LaserGoat/",  "TeamVanquishGoats0", "MpPlant_LaserGoat_Green"},
+        {"Gameplay/Kits/Zombie_LaserGoat_Purple", "Gameplay/Weapons/LaserGoat/",  "TeamVanquishGoats0", "MpZombie_LaserGoat_Purple"},
     };
 
     for (const auto& sk : specialKitDefs)


### PR DESCRIPTION
## What does this change?

This adds an exception for using the laster goat loadout in `TeamVanquishGoats0`, so that it doesn't trigger the loadout anticheat anymore.

## How was it tested?
Tested by hosting and then joining a server with `TeamVanquishGoats0` and enabled anticheat. 
The first connection on a newly started server seems to still throw a warning and kick the user: 
`kit Gameplay/Kits/Zombie_LaserGoat_Purple requires mode TeamVanquishGoats0 but server is running`
It will work without a problem after that initial kick through.

- [ ] GW1
- [X] GW2
- [ ] BFN
- [ ] Launcher only (no DLL change)
- [ ] Backend only (master/relay)

## Checklist

- [x] No new compiler warnings
- [X] Existing functionality not unintentionally broken
- [X] One concern per PR (not mixing unrelated changes)

(new pull request, since the last one got accidentally overwritten after it got merged)